### PR TITLE
added unpadded base64 builtins

### DIFF
--- a/docs/book/src/templating/builtins.md
+++ b/docs/book/src/templating/builtins.md
@@ -16,10 +16,10 @@ Returns the input `value` as base64 encoded string with padding.
 {{ base64 "hello world" }}
 ```
 
-## `base64url`
+## `base64Url`
 
 ```
-base64url <value: string> -> string
+base64Url <value: string> -> string
 ```
 
 Returns the input `value` as base64url encoded string with padding.
@@ -27,7 +27,7 @@ Returns the input `value` as base64url encoded string with padding.
 **Example:**
 
 ```
-{{ base64url "hello world" }}
+{{ base64Url "hello world" }}
 ```
 
 ## `base64Unpadded`
@@ -44,10 +44,10 @@ Returns the input `value` as base64 encoded string without padding.
 {{ base64Unpadded "hello world" }}
 ```
 
-## `base64urlUnpadded`
+## `base64UrlUnpadded`
 
 ```
-base64urlUnpadded <value: string> -> string
+base64UrlUnpadded <value: string> -> string
 ```
 
 Returns the input `value` as base64url encoded string without padding.
@@ -55,7 +55,7 @@ Returns the input `value` as base64url encoded string without padding.
 **Example:**
 
 ```
-{{ base64urlUnpadded "hello world" }}
+{{ base64UrlUnpadded "hello world" }}
 ```
 
 

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -119,9 +119,9 @@ As you can read in these Docs, you can also perform functions on parameters. As 
 Goat also provides some additional functions which are available in Goatfiles.
 
 - `base64 <string>`: Returns the input strings as base64 encoded string with padding.
-- `base64url <string>`: Returns the input strings as base64 URL encoded string with padding.
+- `base64Url <string>`: Returns the input strings as base64 URL encoded string with padding.
 - `base64Unpadded <string>`: Returns the input strings as base64 encoded string without padding.
-- `base64urlUnpadded <string>`: Returns the input strings as base64 URL encoded string without padding.
+- `base64UrlUnpadded <string>`: Returns the input strings as base64 URL encoded string without padding.
 - `md5 <string>`: Returns the HEX encoded MD5 hash of the input string.
 - `sha1 <string>`: Returns the HEX encoded SHA1 hash of the input string.
 - `sha256 <string>`: Returns the HEX encoded SHA256 hash of the input string.

--- a/pkg/goatfile/template_builtins.go
+++ b/pkg/goatfile/template_builtins.go
@@ -20,9 +20,9 @@ var rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 var builtinFuncsMap = template.FuncMap{
 	"base64":            builtin_base64,
-	"base64url":         builtin_base64Url,
+	"base64Url":         builtin_base64Url,
 	"base64Unpadded":    builtin_base64Unpadded,
-	"base64urlUnpadded": builtin_base64UrlUnpadded,
+	"base64UrlUnpadded": builtin_base64UrlUnpadded,
 	"md5":               builtin_hasher(md5.New()),
 	"sha1":              builtin_hasher(sha1.New()),
 	"sha256":            builtin_hasher(sha256.New()),

--- a/pkg/goatfile/util_test.go
+++ b/pkg/goatfile/util_test.go
@@ -229,8 +229,8 @@ func TestApplyTemplate_Builtins(t *testing.T) {
 		assert.Equal(t, "aGVsbG8gd29ybGQ=", res)
 	})
 
-	t.Run("template-builtin-base64url", func(t *testing.T) {
-		const raw = `{{base64url "hello world"}}`
+	t.Run("template-builtin-base64Url", func(t *testing.T) {
+		const raw = `{{base64Url "hello world"}}`
 
 		res, err := ApplyTemplate(raw, nil)
 		assert.Nil(t, err)
@@ -245,8 +245,8 @@ func TestApplyTemplate_Builtins(t *testing.T) {
 		assert.Equal(t, "aGVsbG8gd29ybGQ", res)
 	})
 
-	t.Run("template-builtin-base64urlUnpadded", func(t *testing.T) {
-		const raw = `{{base64urlUnpadded "hello world"}}`
+	t.Run("template-builtin-base64UrlUnpadded", func(t *testing.T) {
+		const raw = `{{base64UrlUnpadded "hello world"}}`
 
 		res, err := ApplyTemplate(raw, nil)
 		assert.Nil(t, err)


### PR DESCRIPTION
Switched current `base64` and `base64url` behavior to include padding and added additional `base64Unpadded` and `base64urlUnpadded` builtins to still allow unpadded base64 encoding.
